### PR TITLE
optional PK for import updates and bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "1.1.3"
+VERSION = "1.1.4"
 
 setup(name='doltpy',
       version=VERSION,


### PR DESCRIPTION
Make the primary key parameter optional so not required for update imports, bump version