### PR TITLE
First cut of Discord notifications

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,4 +26,10 @@ jobs:
     - name: Execute pytest
       run: |
         pytest -m 'not sql_sync'
-
+    - name: Discord Notify
+      if: always()
+      uses: dolthub/ga-discord-notify@master
+      with:
+        job-status: ${{ job.status }}
+        webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+        notify-on-success: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,18 +1,46 @@
 name: Publish to PyPi
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'SemVer format release tag, i.e. 0.23.4'
+        required: true
 
 jobs:
+  bump-version:
+    name: Bump Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Bump Version
+        uses: dolthub/ga-bump-version@master
+        with:
+          version-string: ${{ github.event.inputs.version }}
+          version-file: setup.py
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false
+
   publish:
+    needs: bump-version
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python_version: ['3.9']
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Checkout release
+      run: |
+        git fetch --tags --all
+        git checkout tags/v${{ github.event.inputs.version }} -b v${{ github.event.inputs.version }}
     - name: Set up Python ${{ matrix.python_version }}
       uses: actions/setup-python@v1
       with:
@@ -25,22 +53,10 @@ jobs:
       with:
         user: DoltHub
         password: ${{ secrets.pypi_password }}
-
-  notify:
-    needs: publish
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Get the version
-      id: get_version
-      # GITHUB_REF is expected to be set in the format refs/tags/0.3.1
-      run: echo "::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}"
-    - name: Discord Notification
-      uses: rjstone/discord-webhook-notify@v1
-      with:
-        severity: info
-        username: GhostOfOctacat
-        color: '#ff00aa'
-        avatarUrl: https://github.githubassets.com/images/modules/logos_page/Octocat.png
-        description: "${{format('Doltpy {0}', steps.get_version.outputs.VERSION)}} pushed to PyPi"
-        webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+    - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          notify-on-success: false

--- a/.github/workflows/release-notify.yaml
+++ b/.github/workflows/release-notify.yaml
@@ -1,0 +1,15 @@
+name: Release Notification
+
+on: release
+
+jobs:
+  notify:
+    name: Release Notification
+    steps:
+      - name: Discord Notify
+        if: always()
+        uses: dolthub/ga-discord-notify@master
+        with:
+          job-status: ${{ job.status }}
+          webhook-url: ${{ secrets.DISCORD_RELEASES_WEBHOOK }}
+          notify-on-success: true

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
-VERSION = "1.1.7"
+version = "1.1.7"
 
 setup(name='doltpy',
-      version=VERSION,
+      version=version,
       packages=find_packages(),
       install_requires=['pandas>=1.0.5',
-                        'mysql-connector-python==8.0.20',
+                        'mysql-connector-python==8.0.21',
                         'retry>=0.9.2',
                         'psycopg2-binary>=2.8.5',
                         'psutil>=5.7.0',
@@ -18,7 +18,7 @@ setup(name='doltpy',
       author_email='oscar@dolthub.com',
       description='A Python package for using Dolt database via Python.',
       url='https://github.com/liquidata-inc/doltpy',
-      download_url='https://github.com/liquidata-inc/doltpy/archive/v{}.tar.gz'.format(VERSION),
+      download_url='https://github.com/liquidata-inc/doltpy/archive/v{}.tar.gz'.format(version),
       keywords=['Dolt', 'Liquidata', 'DoltHub', 'ETL', 'ELT'],
       project_urls={'Bug Tracker': 'https://github.com/liquidata-inc/core/issues'},
       entry_points={


### PR DESCRIPTION
This implements the following policy:
- notify on cancellation or failure of any job
- notify on release, including success

Currently release notifications are broken by a shortcoming in GitHub Actions, namely that one workflow cannot kick of another when using `GITHUB_TOKEN`. We will devise a workaround.