### PR TITLE
fix datetime precision loss in clean_types

### DIFF
--- a/doltpy/sql/helpers.py
+++ b/doltpy/sql/helpers.py
@@ -25,7 +25,7 @@ def clean_types(data: Iterable[dict]) -> List[dict]:
     for row in data:
         row_copy: Dict[str, Any] = {}
         for col, val in row.items():
-            if isinstance(val, datetime.date):
+            if not isinstance(val, datetime.datetime) and isinstance(val, datetime.date):
                 row_copy[col] = datetime.datetime.combine(val, datetime.time())
             elif isinstance(val, list):
                 if not val:

--- a/doltpy/sql/helpers.py
+++ b/doltpy/sql/helpers.py
@@ -25,7 +25,11 @@ def clean_types(data: Iterable[dict]) -> List[dict]:
     for row in data:
         row_copy: Dict[str, Any] = {}
         for col, val in row.items():
-            if not isinstance(val, datetime.datetime) and isinstance(val, datetime.date):
+            if isinstance(val, pd.Timestamp):
+                row_copy[col] = val.to_pydatetime()
+            elif isinstance(val, datetime.datetime):
+                row_copy[col] = val
+            elif isinstance(val, datetime.date):
                 row_copy[col] = datetime.datetime.combine(val, datetime.time())
             elif isinstance(val, list):
                 if not val:


### PR DESCRIPTION
``` bash
>>> import datetime
>>> isinstance(datetime.datetime.now(), datetime.date)
True
```

https://til.codeinthehole.com/posts/datetimedatetime-is-a-subclass-of-datetimedate/