### PR TITLE
include primary_key for upsert to avoid ValueError

### DIFF
--- a/doltpy/sql/sync/mysql.py
+++ b/doltpy/sql/sync/mysql.py
@@ -27,6 +27,6 @@ def get_target_writer(engine: Engine, update_on_duplicate: bool = True) -> DoltA
 
 def upsert_helper(table: Table, data: List[dict]):
     insert_statement = insert(table).values(data)
-    update_dict = {el.name: el for el in insert_statement.inserted if not el.primary_key}
+    update_dict = {el.name: el for el in insert_statement.inserted}
     on_duplicate_key_statement = insert_statement.on_duplicate_key_update(update_dict)
     return on_duplicate_key_statement


### PR DESCRIPTION
When syncing a single column table from dolt to mysql,
sqlalchemy will throw a ValueError complaining about an empty update_dict

CREATE TABLE `authority` (
  `name` varchar(50) NOT NULL,
  PRIMARY KEY (`name`)
) ENGINE=InnoDB DEFAULT 
CHARSET=utf8;

https://github.com/zzzeek/sqlalchemy/blob/857adaaf867df54d4a023cf19f618fdf1d0f60c9/lib/sqlalchemy/dialects/mysql/dml.py#L150